### PR TITLE
New functions: `isEmpty`, `front` & `length`

### DIFF
--- a/src/Fifo.elm
+++ b/src/Fifo.elm
@@ -1,4 +1,4 @@
-module Fifo (Fifo, empty, insert, remove, fromList, toList) where
+module Fifo (Fifo, empty, isEmpty, insert, remove, front, length, fromList, toList) where
 
 {-|
 
@@ -10,6 +10,9 @@ module Fifo (Fifo, empty, insert, remove, fromList, toList) where
 
 # To List
 @docs toList
+
+# Checking state
+@docs isEmpty, front, length
 
 -}
 
@@ -29,6 +32,17 @@ empty : Fifo a
 empty =
     Empty
 
+
+{-| Checks whether a Fifo is empty.
+
+    Fifo.empty
+    |> Fifo.insert 7
+    |> Fifo.isEmpty
+        -- == False
+-}
+isEmpty : Fifo a -> Bool
+isEmpty fifo =
+    fifo == Empty
 
 {-| Inserts an item into a Fifo
 
@@ -66,6 +80,39 @@ remove fifo =
 
         Node front (next :: rest) ->
             ( Just front, Node next rest )
+
+
+{-| Reads a Fifo's front value.
+
+    Fifo.fromList [3,7]
+    |> Fifo.front
+        -- == (Just 3)
+
+-}
+front : Fifo a -> Maybe a
+front fifo =
+    case fifo of
+        Empty ->
+            Nothing
+
+        Node front back ->
+            Just front
+
+
+{-| Reports the length of a Fifo.
+
+    Fifo.fromList [3,4,5]
+    |> Fifo.length
+        -- == 3
+
+-}
+length : Fifo a -> Int
+length fifo =
+    case fifo of
+        Empty ->
+            0
+        Node front back ->
+            1 + List.length back
 
 
 {-| Creates a Fifo from a List.

--- a/src/Fifo.elm
+++ b/src/Fifo.elm
@@ -17,8 +17,7 @@ module Fifo (Fifo, empty, insert, remove, fromList, toList) where
 {-| A FIFO containing items of type `a`.
 -}
 type Fifo a
-    = Fifo (List a) (List a)
-
+    = Empty | Node a (List a)
 
 {-| Creates an empty Fifo.
 
@@ -28,7 +27,7 @@ type Fifo a
 -}
 empty : Fifo a
 empty =
-    Fifo [] []
+    Empty
 
 
 {-| Inserts an item into a Fifo
@@ -40,8 +39,13 @@ empty =
 
 -}
 insert : a -> Fifo a -> Fifo a
-insert a (Fifo front back) =
-    Fifo front (a :: back)
+insert a fifo =
+    case fifo of
+        Empty ->
+            Node a []
+
+        Node front back ->
+            Node front (List.append back [a])
 
 
 {-| Removes the next (oldest) item from a Fifo, returning the item (if any), and the updated Fifo.
@@ -54,14 +58,14 @@ insert a (Fifo front back) =
 remove : Fifo a -> ( Maybe a, Fifo a )
 remove fifo =
     case fifo of
-        Fifo [] [] ->
+        Empty ->
             ( Nothing, empty )
 
-        Fifo [] back ->
-            remove <| Fifo (List.reverse back) []
+        Node front [] ->
+            ( Just front, empty )
 
-        Fifo (next :: rest) back ->
-            ( Just next, Fifo rest back )
+        Node front (next :: rest) ->
+            ( Just front, Node next rest )
 
 
 {-| Creates a Fifo from a List.
@@ -74,7 +78,12 @@ remove fifo =
 -}
 fromList : List a -> Fifo a
 fromList list =
-    Fifo list []
+    case list of
+        (first :: rest) ->
+            Node first rest
+
+        [] ->
+            empty
 
 
 {-| Converts a Fifo to a List.
@@ -86,5 +95,10 @@ fromList list =
         -- == [7,9]
 -}
 toList : Fifo a -> List a
-toList (Fifo front back) =
-    front ++ List.reverse back
+toList fifo =
+    case fifo of
+        Empty ->
+            []
+
+        Node front back ->
+            [front] ++ back

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -16,6 +16,24 @@ all =
       |> test "empty FIFO contains nothing",
 
       Fifo.empty
+      |> Fifo.isEmpty
+      |> assertEqual True
+      |> test "empty FIFO is reported as such",
+
+      Fifo.empty
+      |> Fifo.insert 7
+      |> Fifo.isEmpty
+      |> assertEqual False
+      |> test "non-empty FIFO is reported as such",
+
+      Fifo.empty
+      |> Fifo.insert 7
+      |> Fifo.insert 8
+      |> Fifo.front
+      |> assertEqual (Just 7)
+      |> test "can read the front value",
+
+      Fifo.empty
       |> Fifo.insert 9
       |> Fifo.remove |> fst
       |> assertEqual (Just 9)
@@ -43,7 +61,7 @@ all =
       |> Fifo.insert 7
       |> Fifo.remove |> fst
       |> assertEqual (Just 8)
-      |> test "removing an item after inserting after a removal",
+      |> test "can remove an item after removal followed by insertion",
 
       Fifo.empty
       |> Fifo.insert 9
@@ -53,7 +71,16 @@ all =
       |> Fifo.remove |> snd
       |> Fifo.remove |> fst
       |> assertEqual (Just 7)
-      |> test "removing an item inserted after a removal",
+      |> test "can remove an item inserted after a removal",
+
+      Fifo.empty
+      |> Fifo.insert 9
+      |> Fifo.insert 8
+      |> Fifo.remove |> snd
+      |> Fifo.insert 7
+      |> Fifo.length
+      |> assertEqual 2
+      |> test "keeping track of length",
 
       Fifo.empty
       |> Fifo.insert 9

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,7 +9,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "avh4/elm-test": "1.0.2 <= v < 2.0.0",
+        "deadfoxygrandpa/elm-test": "1.0.2 <= v < 2.0.0",
         "elm-lang/core": "2.1.0 <= v < 3.0.0",
         "laszlopandy/elm-console": "1.0.2 <= v < 2.0.0"
     },


### PR DESCRIPTION
Extending the API with well-known functions:
- `isEmpty` reports whether a queue is empty
- `front` is a read-only accessor to inspect a queue's front value
- `length` reports a queue's size

_As this branch is based off the non-merged `rework` branch, it eventually should be rebased against master if #2 is merged. Only 9e1daff is relevant._
