### PR TITLE
Adjust Example to fix usage of `Tuple.second` `Tuple.first`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ main =
     Fifo.empty
     |> Fifo.insert 7
     |> Fifo.insert 42
-    |> Fifo.remove |> Tuple.first
-    |> Fifo.remove |> Tuple.second
+    |> Fifo.remove |> Tuple.second -- gets the updated queue
+    |> Fifo.remove |> Tuple.first -- gets the value at the top
     |> Debug.toString
     |> Html.text
         -- Shows "Just 42"


### PR DESCRIPTION
`Tuple.second` returns the new queue, `Tuple.first` returns the element at the top. The example had these reversed.