### PR TITLE
add Fifo.length function

### DIFF
--- a/src/Fifo.elm
+++ b/src/Fifo.elm
@@ -2,6 +2,7 @@ module Fifo exposing
     ( Fifo, empty, fromList
     , insert, remove
     , toList
+    , length
     )
 
 {-|
@@ -21,13 +22,18 @@ module Fifo exposing
 
 @docs toList
 
+
+# Inspecting
+
+@docs length
+
 -}
 
 
 {-| A FIFO containing items of type `a`.
 -}
 type Fifo a
-    = Fifo (List a) (List a)
+    = Fifo (List a) (List a) Int
 
 
 {-| Creates an empty Fifo.
@@ -38,7 +44,7 @@ type Fifo a
 -}
 empty : Fifo a
 empty =
-    Fifo [] []
+    Fifo [] [] 0
 
 
 {-| Inserts an item into a Fifo
@@ -50,8 +56,8 @@ empty =
 
 -}
 insert : a -> Fifo a -> Fifo a
-insert a (Fifo front back) =
-    Fifo front (a :: back)
+insert a (Fifo front back len) =
+    Fifo front (a :: back) (len + 1)
 
 
 {-| Removes the next (oldest) item from a Fifo, returning the item (if any), and the updated Fifo.
@@ -64,14 +70,14 @@ insert a (Fifo front back) =
 remove : Fifo a -> ( Maybe a, Fifo a )
 remove fifo =
     case fifo of
-        Fifo [] [] ->
+        Fifo [] [] _ ->
             ( Nothing, empty )
 
-        Fifo [] back ->
-            remove <| Fifo (List.reverse back) []
+        Fifo [] back len ->
+            remove <| Fifo (List.reverse back) [] len
 
-        Fifo (next :: rest) back ->
-            ( Just next, Fifo rest back )
+        Fifo (next :: rest) back len ->
+            ( Just next, Fifo rest back (len - 1) )
 
 
 {-| Creates a Fifo from a List.
@@ -84,7 +90,7 @@ remove fifo =
 -}
 fromList : List a -> Fifo a
 fromList list =
-    Fifo list []
+    Fifo list [] (List.length list)
 
 
 {-| Converts a Fifo to a List.
@@ -97,5 +103,19 @@ fromList list =
 
 -}
 toList : Fifo a -> List a
-toList (Fifo front back) =
+toList (Fifo front back _) =
     front ++ List.reverse back
+
+
+{-| Returns the number of items in the Fifo.
+
+    Fifo.fromList [1, 2, 3]
+    |> Fifo.remove
+    |> Tuple.second
+    |> Fifo.length
+        -- == 2
+
+-}
+length : Fifo a -> Int
+length (Fifo _ _ len) =
+    len

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -83,4 +83,22 @@ all =
                     |> Fifo.remove
                     |> Tuple.first
                     |> Expect.equal (Just 2)
+        , test "length" <|
+            \() ->
+                Fifo.fromList [ 1, 2, 3 ]
+                    |> Fifo.length
+                    |> Expect.equal 3
+        , test "length empty" <|
+            \() ->
+                Fifo.empty
+                    |> Fifo.length
+                    |> Expect.equal 0
+
+        , test "length remove" <|
+            \() ->
+                Fifo.fromList [ 1, 2, 3 ]
+                    |> Fifo.remove
+                    |> Tuple.second
+                    |> Fifo.length
+                    |> Expect.equal 2
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -93,7 +93,13 @@ all =
                 Fifo.empty
                     |> Fifo.length
                     |> Expect.equal 0
-
+        , test "length insert" <|
+            \() ->
+                Fifo.empty
+                    |> Fifo.insert 42
+                    |> Fifo.insert 60
+                    |> Fifo.length
+                    |> Expect.equal 2
         , test "length remove" <|
             \() ->
                 Fifo.fromList [ 1, 2, 3 ]


### PR DESCRIPTION
My app frequently wants to know the length of the Fifo (for display to the user) and the Fifo can grow to be thousands of items long, so I want a fast way to obtain that length value. I could use `Fifo.toList |> List.length` but that involves both list reversal (within toList) and traversal again (in List.length) on each call.

So this change has the Fifo keep its current length as part of the state. This does mean additional work on every `insert`, `remove`, and `toList` call to recalculate that length. I have not benchmarked any times before and after this change.

If this PR is unacceptable, please let me know and I'll probably publish my forked version as a new package.
